### PR TITLE
overide get_url_params

### DIFF
--- a/tap_gorgias/streams.py
+++ b/tap_gorgias/streams.py
@@ -648,6 +648,13 @@ class EventStream(GorgiasStream):
 
     schema_filepath = SCHEMAS_DIR / "events.json"
 
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        sync_start_datetime = self.get_starting_timestamp(context)
+        dt_str = sync_start_datetime.replace(tzinfo=None).isoformat()
+        return {"cursor": next_page_token, "limit": self.config["page_size"], "created_datetime[gte]":dt_str}
+
     def post_process(self, row: dict, context: dict = None) -> dict:
         if row:
             data = row.get('data')


### PR DESCRIPTION
- in order to enforce incremental loads in the events stream, I have overridden an inherited method `get_url_params`, which allows me to add a filtering parameter specific to the events list endpoint that allows users to filter event by `created_datetime`