### PR TITLE
Add support for custom fields in `TicketDetails` stream

### DIFF
--- a/tap_gorgias/streams.py
+++ b/tap_gorgias/streams.py
@@ -364,6 +364,14 @@ class TicketDetailsStream(GorgiasStream):
                 )
             ),
         ),
+        th.Property(
+            "custom_fields",
+            th.ObjectType(
+                th.Property("6399", th.ObjectType(th.Property("value", th.StringType))),
+                th.Property("6633", th.ObjectType(th.Property("value", th.StringType))),
+                th.Property("6634", th.ObjectType(th.Property("value", th.StringType))),
+            ),
+        ),
         th.Property("trashed_datetime", th.DateTimeType),
         th.Property("updated_datetime", th.DateTimeType),
         th.Property("via", th.StringType),

--- a/tap_gorgias/streams.py
+++ b/tap_gorgias/streams.py
@@ -667,6 +667,17 @@ class EventStream(GorgiasStream):
         if row:
             data = row.get('data')
             if data:
+                # Custom fields should be renamed for clarity
+                if 'custom_fields' in data:
+                    if '6399' in data['custom_fields']:
+                        data['custom_fields']['custom__ticket_category'] = data['custom_fields']['6399']
+                        data['custom_fields'].pop('6399', None)
+                    if '6633' in data['custom_fields']:
+                        data['custom_fields']['custom__related_to_a_can'] = data['custom_fields']['6633']
+                        data['custom_fields'].pop('6633', None)
+                    if '6634' in data['custom_fields']:                        
+                        data['custom_fields']['custom__retailer'] = data['custom_fields']['6634']
+                        data['custom_fields'].pop('6634', None)
                 row['data'] = json.dumps(data)
         return row
 

--- a/tap_gorgias/streams.py
+++ b/tap_gorgias/streams.py
@@ -269,7 +269,7 @@ class TicketDetailsStream(GorgiasStream):
     """Uses tickets as a parent stream. This stream is used to get the details of a ticket which are not available
     in the List Ticket view, like spam or integration details."""
 
-    name = "ticket_details_tmp"
+    name = "ticket_details"
     parent_stream_type = TicketsStream
     path = "/api/tickets/{ticket_id}"
     primary_keys = ["id"]

--- a/tap_gorgias/streams.py
+++ b/tap_gorgias/streams.py
@@ -269,7 +269,7 @@ class TicketDetailsStream(GorgiasStream):
     """Uses tickets as a parent stream. This stream is used to get the details of a ticket which are not available
     in the List Ticket view, like spam or integration details."""
 
-    name = "ticket_details"
+    name = "ticket_details_tmp"
     parent_stream_type = TicketsStream
     path = "/api/tickets/{ticket_id}"
     primary_keys = ["id"]


### PR DESCRIPTION
This PR adds three custom fields (identified with numerical IDs) to the schema of the `TicketDetails` stream, and renames them to humanly readable names.