### PR TITLE
set is_sorted to false

### DIFF
--- a/tap_gorgias/streams.py
+++ b/tap_gorgias/streams.py
@@ -31,7 +31,7 @@ class TicketsStream(GorgiasStream):
     path = "/api/views/{view_id}/items"
     primary_keys = ["id"]
     replication_key = "updated_datetime"
-    is_sorted = True
+    # is_sorted = True
 
     # Link to the next items, if any.
     next_page_token_jsonpath = "$.meta.next_items"


### PR DESCRIPTION
The meltano Tap has been failing recently as a result of an InvalidStreamSort execption. It seems like the behavior of the gorgias API changed which led to continous fails in running the pipeline as a result of this error.

This PR changes the Ticket stream behavior  by reverting back to the RestStream default sort behavior (setting is_sorted to false)